### PR TITLE
Update check of response for service health

### DIFF
--- a/check_b2stage_http-api.py
+++ b/check_b2stage_http-api.py
@@ -95,7 +95,10 @@ def checkHealth(URL, timeout):
         return description, exit_code
 
     content = out.json()
-    resp = content['Response']['data']
+    if 'Response' in content:
+        resp = content['Response']['data']
+    else:
+        resp = content
 
     if not resp.startswith("Server is alive"):
         description = "WARNING - Unexpected response: %s" % resp


### PR DESCRIPTION
Original response was:
{
    "Meta": {
        "data_type": "<class 'str'>",
        "elements": 1,
        "errors": 0,
        "status": 200
    },
    "Response": {
        "data": "Server is alive",
        "errors": null
    }
}
The response is now 
"Server is alive"

So i updated the probe to get the correct response.